### PR TITLE
chore: fix VSCode marketplace url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Untyped `throw` statements can be a pain for those who come from languages like 
 
 | Platform | Installation |
 | -------- | ------------ |
-| VsCode  | via [Marketplace](https://marketplace.visualstudio.com/items?itemName=michaelangeloio.does-it-throw) |
+| VsCode  | via [Marketplace](https://marketplace.visualstudio.com/items?itemName=michaelangeloio.does-it-throw-vscode) |
 | NeoVim	| Coming soon... |
 
 > This extension is built with security in mind. It doesn't send any data to any third party servers. All publishes are done via a signed immutable commit from the [CI pipeline](https://github.com/michaelangeloio/does-it-throw/blob/update-details/.github/workflows/release-please.yaml).


### PR DESCRIPTION
Hey, it looks like VSCode marketplace url is changed.