### PR TITLE
fix: functions and throw statements are underlined even if caught

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,4 +21,4 @@
     "editor.defaultFormatter": "biomejs.biome"
   },
   "doesItThrow.trace.server": "verbose"
-}
+} 

--- a/crates/does-it-throw/src/fixtures/.vscode/settings.json
+++ b/crates/does-it-throw/src/fixtures/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "doesItThrow.trace.server": "verbose"
+  "doesItThrow.trace.server": "verbose",
+  "doesItThrow.includeTryStatementThrows": false
 }

--- a/crates/does-it-throw/src/fixtures/something.ts
+++ b/crates/does-it-throw/src/fixtures/something.ts
@@ -1,0 +1,7 @@
+export const SomeThrow = () => {
+    throw new Error('never gonna let you down');
+}
+
+export function Something () {
+  throw new Error('never gonna run around and desert you')
+}

--- a/crates/does-it-throw/src/fixtures/tryStatement.ts
+++ b/crates/does-it-throw/src/fixtures/tryStatement.ts
@@ -1,0 +1,148 @@
+// @ts-nocheck
+export const someConstThatThrows = () => {
+  try {
+    throw new Error('never gonna give you up')
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+function callToConstThatThrows4() {
+  someConstThatThrows()
+}
+
+const someCondition = true
+export class Something {
+  constructor() {
+    try {
+      throw new Error('hi khue')
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
+  someMethodThatThrows() {
+    try {
+      throw new Error('hi khue')
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
+  someMethodThatDoesNotThrow() {
+    console.log('hi khue')
+  }
+
+  someMethodThatThrows2() {
+    if (someCondition) {
+      throw new Error('hi khue')
+    }
+  }
+
+  nestedThrow() {
+    try {
+      if (someCondition) {
+        return true
+      }
+      throw new Error('hi khue')
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
+  callNestedThrow() {
+    if (someCondition) {
+      return true
+    }
+    if (someCondition) {
+      return true
+    }
+    this.nestedThrow()
+  }
+}
+
+const _somethingCall = () => {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+export const somethingCall = () => {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+function _somethingCall2() {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+export function somethingCall2() {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+// @ts-nocheck
+// should work for private class
+class SomeClass {
+  constructor(public x: number) {}
+
+  async _contextFromWorkflow() {
+    try {
+      throw new Error('Some error')
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
+  async someCallToThrow() {
+    const { user, stravaUser, streakContext } = opts?.contextFromWorkFlow ?? (await this._contextFromWorkflow(job))
+  }
+}
+
+// should work for exported class
+// biome-ignore lint/suspicious/noRedeclare: <explanation>
+export class SomeClass2 {
+  constructor(public x: number) {}
+
+  async _contextFromWorkflow() {
+    try {
+      throw new Error('Some error')
+    } catch (e) {
+      console.log(e)
+    }
+  }
+
+  async someCallToThrow() {
+    const { user, stravaUser, streakContext } = opts?.contextFromWorkFlow ?? (await this._contextFromWorkflow(job))
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  switch (req.url) {
+    case '/api/pong':
+      console.log('pong!', INSTANCE_ID, PRIVATE_IP)
+      try {
+        throw new Error('')
+      } catch (e) {
+        console.log(e)
+      }
+      break
+    case '/api/ping':
+      console.log('ping!', INSTANCE_ID, PRIVATE_IP)
+      const ips = await SomeThrow()
+      someObjectLiteral.objectLiteralThrow()
+      const others = ips.filter((ip) => ip !== PRIVATE_IP)
+
+      others.forEach((ip) => {
+        http.get(`http://[${ip}]:8080/api/pong`)
+      })
+      break
+    case '/api/throw':
+      someRandomThrow()
+      break
+  }
+
+  res.end()
+})
+
+const wss = new WebSocketServer({ noServer: true })

--- a/crates/does-it-throw/src/lib.rs
+++ b/crates/does-it-throw/src/lib.rs
@@ -49,7 +49,15 @@ impl From<CombinedAnalyzers> for AnalysisResult {
   }
 }
 
-pub fn analyze_code(content: &str, cm: Lrc<SourceMap>) -> (AnalysisResult, Lrc<SourceMap>) {
+pub struct UserSettings {
+  pub include_try_statement_throws: bool,
+}
+
+pub fn analyze_code(
+  content: &str,
+  cm: Lrc<SourceMap>,
+  user_settings: &UserSettings,
+) -> (AnalysisResult, Lrc<SourceMap>) {
   let fm = cm.new_source_file(swc_common::FileName::Anon, content.into());
   let lexer = Lexer::new(
     Syntax::Typescript(swc_ecma_parser::TsConfig {
@@ -75,6 +83,7 @@ pub fn analyze_code(content: &str, cm: Lrc<SourceMap>) -> (AnalysisResult, Lrc<S
     function_name_stack: vec![],
     current_class_name: None,
     current_method_name: None,
+    include_try_statement: user_settings.include_try_statement_throws,
   };
   throw_collector.visit_module(&module);
   let mut call_collector = CallFinder {

--- a/crates/does-it-throw/src/main.rs
+++ b/crates/does-it-throw/src/main.rs
@@ -3,14 +3,16 @@ extern crate swc_common;
 use std::fs;
 
 use self::swc_common::{sync::Lrc, SourceMap};
-use does_it_throw::analyze_code;
+use does_it_throw::{analyze_code, UserSettings};
 
 pub fn main() {
   let sample_code = fs::read_to_string("crates/does-it-throw/src/fixtures/sample.ts")
     .expect("Something went wrong reading the file");
   let cm: Lrc<SourceMap> = Default::default();
-
-  let (result, _cm) = analyze_code(&sample_code, cm);
+  let user_settings = UserSettings {
+    include_try_statement_throws: false,
+  };
+  let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
   for import in result.import_sources.into_iter() {
     println!("Imported {}", import);
   }
@@ -75,8 +77,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 4);
@@ -134,8 +138,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 4);
@@ -193,8 +199,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 4);
@@ -247,8 +255,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 4);
@@ -302,8 +312,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 3);
@@ -356,8 +368,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 3);
@@ -409,8 +423,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 5);
@@ -467,8 +483,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 4);
@@ -517,8 +535,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 4);
@@ -567,8 +587,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 0);
@@ -616,8 +638,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 2);
@@ -660,8 +684,10 @@ mod integration_tests {
     // Read sample code from file
     let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
     let cm: Lrc<SourceMap> = Default::default();
-
-    let (result, _cm) = analyze_code(&sample_code, cm);
+    let user_settings = UserSettings {
+      include_try_statement_throws: false,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
     // general result assertions
     assert_eq!(result.functions_with_throws.len(), 2);
@@ -720,5 +746,70 @@ mod integration_tests {
     ["someObjectLiteral-objectLiteralThrow", "NOT_SET-SomeThrow"]
       .iter()
       .for_each(|f| assert!(import_identifiers_contains(&import_identifiers, f)));
+  }
+
+  #[test]
+  fn test_try_statement() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let file_path = format!("{}/src/fixtures/tryStatement.ts", manifest_dir);
+    // Read sample code from file
+    let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let user_settings = UserSettings {
+      include_try_statement_throws: true,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
+
+    // general result assertions
+    assert_eq!(result.functions_with_throws.len(), 8);
+    assert_eq!(result.calls_to_throws.len(), 9);
+    assert_eq!(result.imported_identifier_usages.len(), 0);
+    assert_eq!(result.import_sources.len(), 0);
+
+    // function names
+    let function_names: Vec<String> = result
+      .functions_with_throws
+      .clone()
+      .into_iter()
+      .map(|f| f.function_or_method_name)
+      .collect();
+    fn function_names_contains(function_names: &Vec<String>, function_name: &str) -> bool {
+      function_names.iter().any(|f| f == function_name)
+    }
+
+    [
+      "someMethodThatThrows",
+      "_contextFromWorkflow",
+      "createServer",
+      "<constructor>",
+      "someConstThatThrows",
+      "nestedThrow",
+      "_contextFromWorkflow",
+      "someMethodThatThrows2",
+    ]
+    .iter()
+    .for_each(|f| assert!(function_names_contains(&function_names, f)));
+
+    // calls to throws
+    let calls_to_throws: Vec<String> = result.calls_to_throws.into_iter().map(|c| c.id).collect();
+
+    fn calls_to_throws_contains(calls_to_throws: &Vec<String>, call_to_throw: &str) -> bool {
+      calls_to_throws.iter().any(|c| c == call_to_throw)
+    }
+
+    [
+      "Something-somethingCall",
+      "Something-_somethingCall2",
+      "NOT_SET-someCallToThrow",
+      "Something-somethingCall2",
+      "http-<anonymous>",
+      "Something-_somethingCall",
+      "NOT_SET-callNestedThrow",
+      "NOT_SET-callToConstThatThrows4",
+      "NOT_SET-someCallToThrow",
+    ]
+    .iter()
+    .for_each(|f| assert!(calls_to_throws_contains(&calls_to_throws, f)));
   }
 }

--- a/docs/neovim.md
+++ b/docs/neovim.md
@@ -53,6 +53,7 @@ local server_config = {
         functionThrowSeverity = "Hint",
         callToThrowSeverity = "Hint",
         callToImportedThrowSeverity = "Hint",
+        includeTryStatementThrows = false,
         maxNumberOfProblems = 10000
     }
 }

--- a/package.json
+++ b/package.json
@@ -127,6 +127,12 @@
           "default": 100,
           "description": "Controls the maximum number of problems produced by the server."
         },
+        "doesItThrow.includeTryStatementThrows": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Include throw statements inside try statements."
+        },
         "doesItThrow.trace.server": {
           "scope": "window",
           "type": "string",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -81,6 +81,7 @@ interface Settings {
   functionThrowSeverity: DiagnosticSeverity
   callToThrowSeverity: DiagnosticSeverity
   callToImportedThrowSeverity: DiagnosticSeverity
+  includeTryStatementThrows: boolean
 }
 
 // The global settings, used when the `workspace/configuration` request is not supported by the client.
@@ -91,7 +92,8 @@ const defaultSettings: Settings = {
   throwStatementSeverity: 'Hint',
   functionThrowSeverity: 'Hint',
   callToThrowSeverity: 'Hint',
-  callToImportedThrowSeverity: 'Hint'
+  callToImportedThrowSeverity: 'Hint',
+  includeTryStatementThrows: false
 }
 // 👆 very unlikely someone will have more than 1 million throw statements, lol
 // if you do, might want to rethink your code?
@@ -183,7 +185,8 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
       function_throw_severity: settings.functionThrowSeverity,
       throw_statement_severity: settings.throwStatementSeverity,
       call_to_imported_throw_severity: settings.callToImportedThrowSeverity,
-      call_to_throw_severity: settings.callToThrowSeverity
+      call_to_throw_severity: settings.callToThrowSeverity,
+      include_try_statement_throws: settings.includeTryStatementThrows
     } satisfies InputData
     const analysis = parse_js(opts) as ParseResult
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -182,11 +182,12 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
       typescript_settings: {
         decorators: true
       },
-      function_throw_severity: settings.functionThrowSeverity,
-      throw_statement_severity: settings.throwStatementSeverity,
-      call_to_imported_throw_severity: settings.callToImportedThrowSeverity,
-      call_to_throw_severity: settings.callToThrowSeverity,
-      include_try_statement_throws: settings.includeTryStatementThrows
+      function_throw_severity: settings?.functionThrowSeverity ?? defaultSettings.functionThrowSeverity,
+      throw_statement_severity: settings?.throwStatementSeverity ?? defaultSettings.throwStatementSeverity,
+      call_to_imported_throw_severity:
+        settings?.callToImportedThrowSeverity ?? defaultSettings.callToImportedThrowSeverity,
+      call_to_throw_severity: settings?.callToThrowSeverity ?? defaultSettings.callToThrowSeverity,
+      include_try_statement_throws: settings?.includeTryStatementThrows ?? defaultSettings.includeTryStatementThrows
     } satisfies InputData
     const analysis = parse_js(opts) as ParseResult
 


### PR DESCRIPTION
closes #71 

# Summary of Changes
- Adds a new setting called `includeTryStatementThrows`. If enabled, the linter will also mark errors under try/catch statements
- This behavior is now false as default 
- Added some tests for this fix

## Notes
- This should have been default behavior from the get-go, so I am marking this as a patch change.
  - A test has been added under `main.rs` for the main does-it-throw crate to ensure this backwards compatibility