### PR TITLE
fix: jetbrains build.gradle since/until build version requirements

### DIFF
--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -96,8 +96,7 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("233")
-        untilBuild.set("240.*")
+        sinceBuild = properties("pluginSinceBuild")
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         val readMe = layout.projectDirectory.file(file("${project.projectDir}/../README.md").path)

--- a/jetbrains/gradle.properties
+++ b/jetbrains/gradle.properties
@@ -6,7 +6,6 @@ pluginName=Does it Throw?
 pluginVersion=0.3.3
 # x-release-please-end
 pluginSinceBuild=223
-pluginUntilBuild=223.*
 platformType=IU
 platformVersion=2023.3
 platformPlugins=JavaScript


### PR DESCRIPTION
Versioning requirement is too strict. 