### PR TITLE
feat: user can now discard warnings with ignore statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Untyped `throw` statements can be a pain for those who come from languages like 
 
 > The core of the code is written in Rust, and the LSP implementation for VsCode is written in Typescript. The Rust code is compiled to WASM and bundled with the VsCode extension. The extension is published to the VsCode marketplace, and the Rust code is published to [crates.io](https://crates.io/crates/does-it-throw). 
 
+## Usage
+
+For a usage and configuration guide, check out the [usage](https://github.com/michaelangeloio/does-it-throw/blob/main/docs/usage.md) page!
+
 
 ## Limitations
 

--- a/crates/does-it-throw-wasm/src/lib.rs
+++ b/crates/does-it-throw-wasm/src/lib.rs
@@ -404,6 +404,7 @@ interface InputData {
   call_to_throw_severity?: DiagnosticSeverityInput;
   call_to_imported_throw_severity?: DiagnosticSeverityInput;
   include_try_statement_throws?: boolean;
+  ignore_statements?: string[];
 }
 "#;
 
@@ -449,6 +450,7 @@ pub struct InputData {
   pub call_to_throw_severity: Option<DiagnosticSeverityInput>,
   pub call_to_imported_throw_severity: Option<DiagnosticSeverityInput>,
   pub include_try_statement_throws: Option<bool>,
+  pub ignore_statements: Option<Vec<String>>,
 }
 
 #[wasm_bindgen]
@@ -460,6 +462,7 @@ pub fn parse_js(data: JsValue) -> JsValue {
 
   let user_settings = UserSettings {
     include_try_statement_throws: input_data.include_try_statement_throws.unwrap_or(false),
+    ignore_statements: input_data.ignore_statements.clone().unwrap_or_else(Vec::new),
   };
 
   let (results, cm) = analyze_code(&input_data.file_content, cm, &user_settings);

--- a/crates/does-it-throw/src/fixtures/.vscode/settings.json
+++ b/crates/does-it-throw/src/fixtures/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
   "doesItThrow.trace.server": "verbose",
-  "doesItThrow.includeTryStatementThrows": false
+  "doesItThrow.includeTryStatementThrows": false,
+  "doesItThrow.ignoreStatements": [
+    "@it-throws",
+    "@does-it-throw-ignore",
+    "@some-random-ignore"
+  ]
 }

--- a/crates/does-it-throw/src/fixtures/ignoreStatements.js
+++ b/crates/does-it-throw/src/fixtures/ignoreStatements.js
@@ -1,0 +1,96 @@
+// @ts-nocheck
+const someCondition = true
+export class Something {
+  constructor() {
+    //@it-throws
+    throw new Error('hi khue')
+  }
+
+  someMethodThatThrows() {
+    //@it-throws
+    throw new Error('hi khue')
+  }
+
+  someMethodThatDoesNotThrow() {
+    console.log('hi khue')
+  }
+
+  someMethodThatThrows2() {
+    if (someCondition) {
+      //@it-throws
+      throw new Error('hi khue')
+    }
+  }
+
+  nestedThrow() {
+    if (someCondition) {
+      return true
+    }
+    //@it-throws
+    throw new Error('hi khue')
+  }
+
+  callNestedThrow() {
+    if (someCondition) {
+      return true
+    }
+    if (someCondition) {
+      return true
+    }
+    this.nestedThrow()
+  }
+}
+
+const _somethingCall = () => {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+export const somethingCall = () => {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+
+const someRandomThrow = () => {
+  //@it-throws
+  throw new Error('some random throw')
+}
+
+const server = http.createServer(async (req, res) => {
+  switch (req.url) {
+    case '/api/pong':
+      console.log('pong!', INSTANCE_ID, PRIVATE_IP)
+      //@it-throws
+      throw new Error('')
+      break
+    case '/api/ping':
+      console.log('ping!', INSTANCE_ID, PRIVATE_IP)
+      const ips = await SomeThrow()
+      someObjectLiteral.objectLiteralThrow()
+      const others = ips.filter((ip) => ip !== PRIVATE_IP)
+
+      others.forEach((ip) => {
+        http.get(`http://[${ip}]:8080/api/pong`)
+      })
+      break
+    case '/api/throw':
+      someRandomThrow()
+      break
+  }
+
+  res.end()
+})
+
+const wss = new WebSocketServer({ noServer: true })
+
+
+function _somethingCall2() {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+export function somethingCall2() {
+  const something = new Something()
+  something.someMethodThatThrows()
+}

--- a/crates/does-it-throw/src/fixtures/ignoreStatements.ts
+++ b/crates/does-it-throw/src/fixtures/ignoreStatements.ts
@@ -1,0 +1,144 @@
+// @ts-nocheck
+const someCondition = true
+export class Something {
+  constructor() {
+    // @it-throws
+    throw new Error('hi khue')
+  }
+
+  someMethodThatThrows() {
+    // @it-throws
+    throw new Error('hi khue')
+  }
+
+  someMethodThatDoesNotThrow() {
+    console.log('hi khue')
+  }
+
+  someMethodThatThrows2() {
+    if (someCondition) {
+      // @some-random-ignore
+      throw new Error('hi khue')
+    }
+  }
+
+  nestedThrow() {
+    if (someCondition) {
+      return true
+    }
+    // @it-throws-ignore
+    throw new Error('hi khue')
+  }
+
+  callNestedThrow() {
+    if (someCondition) {
+      return true
+    }
+    if (someCondition) {
+      return true
+    }
+    this.nestedThrow()
+  }
+}
+
+const _somethingCall = () => {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+export const somethingCall = () => {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+
+const someRandomThrow = () => {
+  //@it-throws
+  throw new Error('some random throw')
+}
+
+const server = http.createServer(async (req, res) => {
+  switch (req.url) {
+    case '/api/pong':
+      console.log('pong!', INSTANCE_ID, PRIVATE_IP)
+      //@it-throws
+      throw new Error('')
+      break
+    case '/api/ping':
+      console.log('ping!', INSTANCE_ID, PRIVATE_IP)
+      const ips = await SomeThrow()
+      someObjectLiteral.objectLiteralThrow()
+      const others = ips.filter((ip) => ip !== PRIVATE_IP)
+
+      others.forEach((ip) => {
+        http.get(`http://[${ip}]:8080/api/pong`)
+      })
+      break
+    case '/api/throw':
+      someRandomThrow()
+      break
+  }
+
+  res.end()
+})
+
+const wss = new WebSocketServer({ noServer: true })
+
+
+function _somethingCall2() {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+export function somethingCall2() {
+  const something = new Something()
+  something.someMethodThatThrows()
+}
+
+
+// @ts-nocheck
+const connection = {}
+
+const SomeThrow = () => {
+  //@it-throws
+  throw new Error('hi khue')
+}
+
+function SomeThrow2() {
+  //@it-throws
+  throw new Error('hi khue')
+}
+
+connection.onInitialized(() => {
+  if (hasConfigurationCapability) {
+    // Register for all configuration changes.
+    connection.client.register(DidChangeConfigurationNotification.type, undefined)
+  }
+  if (hasWorkspaceFolderCapability) {
+    connection.workspace.onDidChangeWorkspaceFolders((_event) => {
+      connection.console.log(`Workspace folder change event received. ${JSON.stringify(_event)}`)
+    })
+  }
+  SomeThrow()
+  SomeThrow2()
+})
+
+connection.onInitialized2(() => {
+  //@it-throws
+  throw new Error('hi khue')
+})
+
+SomeRandomCall(() => {
+  //@it-throws
+  throw new Error('hi khue')
+})
+
+SomeRandomCall2(() => {
+  SomeThrow()
+  SomeThrow2()
+})
+
+connection.oneWithASecondArg({}, () => {
+  //@it-throws
+  throw new Error('hi khue')
+})

--- a/crates/does-it-throw/src/fixtures/sample.ts
+++ b/crates/does-it-throw/src/fixtures/sample.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 export const someConstThatThrows = () => {
+  // @it-throws
   throw new Error('hi khue')
 }
 

--- a/crates/does-it-throw/src/fixtures/sample.ts
+++ b/crates/does-it-throw/src/fixtures/sample.ts
@@ -1,7 +1,6 @@
 // @ts-nocheck
 
 export const someConstThatThrows = () => {
-  // @it-throws
   throw new Error('hi khue')
 }
 

--- a/crates/does-it-throw/src/lib.rs
+++ b/crates/does-it-throw/src/lib.rs
@@ -30,13 +30,13 @@ pub struct AnalysisResult {
   pub imported_identifier_usages: HashSet<IdentifierUsage>,
 }
 
-struct CombinedAnalyzers<'ignorestmt_lt>  {
-  throw_analyzer: ThrowAnalyzer<'ignorestmt_lt>,
+struct CombinedAnalyzers<'throwfinder_settings>  {
+  throw_analyzer: ThrowAnalyzer<'throwfinder_settings>,
   call_finder: CallFinder,
   import_usage_finder: ImportUsageFinder,
 }
 
-impl <'ignoretmt_lt> From<CombinedAnalyzers<'ignoretmt_lt>> for AnalysisResult {
+impl <'throwfinder_settings> From<CombinedAnalyzers<'throwfinder_settings>> for AnalysisResult {
   fn from(analyzers: CombinedAnalyzers) -> Self {
     Self {
       functions_with_throws: analyzers.throw_analyzer.functions_with_throws,

--- a/crates/does-it-throw/src/main.rs
+++ b/crates/does-it-throw/src/main.rs
@@ -960,4 +960,25 @@ mod integration_tests {
     assert_eq!(result.calls_to_throws.len(), 0);
   }
 
+  #[test]
+  fn test_should_not_include_throws_for_ignore_statements_js () {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let file_path = format!("{}/src/fixtures/ignoreStatements.js", manifest_dir);
+    // Read sample code from file
+    let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
+    let ignore_statements = vec![
+      "@it-throws".to_string(),
+      "@it-throws-ignore".to_string(),
+      "@some-random-ignore".to_string(),
+    ];
+    let cm: Lrc<SourceMap> = Default::default();
+    let user_settings = UserSettings {
+      include_try_statement_throws: true,
+      ignore_statements,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
+
+    assert_eq!(result.functions_with_throws.len(), 0);
+    assert_eq!(result.calls_to_throws.len(), 0);
+  }
 }

--- a/crates/does-it-throw/src/main.rs
+++ b/crates/does-it-throw/src/main.rs
@@ -11,6 +11,7 @@ pub fn main() {
   let cm: Lrc<SourceMap> = Default::default();
   let user_settings = UserSettings {
     include_try_statement_throws: false,
+    ignore_statements: vec!["@it-throws".to_string()],
   };
   let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
   for import in result.import_sources.into_iter() {
@@ -79,6 +80,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -140,6 +142,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -201,6 +204,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -257,6 +261,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -314,6 +319,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -370,6 +376,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -425,6 +432,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -485,6 +493,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -537,6 +546,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -589,6 +599,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -640,6 +651,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -686,6 +698,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -758,6 +771,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: true,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -814,7 +828,7 @@ mod integration_tests {
   }
 
   #[test]
-  fn test_try_statement_does_not_include_all_throws () {
+  fn test_try_statement_does_not_include_all_throws() {
     // This test is the same as test_try_statement but with include_try_statement_throws set to false
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let file_path = format!("{}/src/fixtures/tryStatement.ts", manifest_dir);
@@ -824,6 +838,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -840,6 +855,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: true,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -851,7 +867,7 @@ mod integration_tests {
   }
 
   #[test]
-  fn test_try_statement_nested_does_not_include_throws () {
+  fn test_try_statement_nested_does_not_include_throws() {
     // We need to test the following conditions:
     // 1. include_try_statement_throws = false
     // 2. a nested try statement that throws that ISNT caught by the parent try statement
@@ -864,6 +880,7 @@ mod integration_tests {
     let cm: Lrc<SourceMap> = Default::default();
     let user_settings = UserSettings {
       include_try_statement_throws: false,
+      ignore_statements: vec!["@it-throws".to_string()],
     };
     let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
 
@@ -884,4 +901,63 @@ mod integration_tests {
       .iter()
       .for_each(|f| assert!(function_names_contains(&function_names, f)));
   }
+
+  #[test]
+  fn test_should_include_throws_for_no_ignore_statements() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let file_path = format!("{}/src/fixtures/ignoreStatements.ts", manifest_dir);
+    // Read sample code from file
+    let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let user_settings = UserSettings {
+      include_try_statement_throws: true,
+      ignore_statements: vec![],
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
+
+    assert_eq!(result.functions_with_throws.len(), 11);
+    assert_eq!(result.calls_to_throws.len(), 15);
+  }
+
+  #[test]
+  fn test_should_include_throws_for_no_ignore_statements_js() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let file_path = format!("{}/src/fixtures/ignoreStatements.js", manifest_dir);
+    // Read sample code from file
+    let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let user_settings = UserSettings {
+      include_try_statement_throws: true,
+      ignore_statements: vec![],
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
+
+    assert_eq!(result.functions_with_throws.len(), 6);
+    assert_eq!(result.calls_to_throws.len(), 7);
+  }
+
+  #[test]
+  fn test_should_not_include_throws_for_ignore_statements () {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let file_path = format!("{}/src/fixtures/ignoreStatements.ts", manifest_dir);
+    // Read sample code from file
+    let sample_code = fs::read_to_string(file_path).expect("Something went wrong reading the file");
+    let ignore_statements = vec![
+      "@it-throws".to_string(),
+      "@it-throws-ignore".to_string(),
+      "@some-random-ignore".to_string(),
+    ];
+    let cm: Lrc<SourceMap> = Default::default();
+    let user_settings = UserSettings {
+      include_try_statement_throws: true,
+      ignore_statements,
+    };
+    let (result, _cm) = analyze_code(&sample_code, cm, &user_settings);
+
+    assert_eq!(result.functions_with_throws.len(), 0);
+    assert_eq!(result.calls_to_throws.len(), 0);
+  }
+
 }

--- a/crates/does-it-throw/src/throw_finder.rs
+++ b/crates/does-it-throw/src/throw_finder.rs
@@ -183,7 +183,7 @@ impl Hash for ThrowMap {
   }
 }
 
-pub struct ThrowAnalyzer<'ignorestmt_lt> {
+pub struct ThrowAnalyzer<'throwfinder_settings> {
   pub comments: Lrc<dyn Comments>,
   pub functions_with_throws: HashSet<ThrowMap>,
   pub json_parse_calls: Vec<String>,
@@ -193,7 +193,7 @@ pub struct ThrowAnalyzer<'ignorestmt_lt> {
   pub function_name_stack: Vec<String>,
   pub current_class_name: Option<String>,
   pub current_method_name: Option<String>,
-  pub throwfinder_settings: ThrowFinderSettings<'ignorestmt_lt>,
+  pub throwfinder_settings: ThrowFinderSettings<'throwfinder_settings>,
 }
 
 impl<'throwfinder_settings> ThrowAnalyzer<'throwfinder_settings> {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,37 @@
+## Configuration Options
+
+Here's a table of all the configuration options:
+
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+| `throwStatementSeverity` | The severity of the throw statement diagnostics. | `Hint` |
+| `functionThrowSeverity` | The severity of the function throw diagnostics. | `Hint` |
+| `callToThrowSeverity` | The severity of the call to throw diagnostics. | `Hint` |
+| `callToImportedThrowSeverity` | The severity of the call to imported throw diagnostics. | `Hint` |
+| `includeTryStatementThrows` | Whether to include throw statements inside try statements. | `false` |
+| `maxNumberOfProblems` | The maximum number of problems to report. | `10000` |
+| `ignoreStatements` | A list/array of statements to ignore. | `["@it-throws", "@does-it-throw-ignore"]` |
+
+## Ignoring Throw Statement Warnings
+
+You can ignore throw statement warnings by adding the following comment to the line above the throw statement:
+
+```typescript
+const someThrow = () => {
+  // @does-it-throw-ignore
+  throw new Error("This will not be reported");
+};
+```
+
+Any calls to functions/methods that `throw` that are marked with the `@it-throws` or `@does-it-throw-ignore` comment will also be ignored as a result. For example:
+
+```typescript
+const someThrow = () => {
+  // @does-it-throw-ignore
+  throw new Error("This will not be reported");
+};
+
+const callToThrow = () => {
+  someThrow(); // This will not be reported
+};
+```

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
             "type": "string"
           },
           "default": ["@it-throws", "@does-it-throw-ignore"],
-          "description": "Ignore throw statements with comments that match these strings."
+          "description": "Ignore throw statements with comments above that match these strings."
         },
         "doesItThrow.trace.server": {
           "scope": "window",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,15 @@
           "default": false,
           "description": "Include throw statements inside try statements."
         },
+        "doesItThrow.ignoreStatements": {
+          "scope": "resource",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["@it-throws", "@does-it-throw-ignore"],
+          "description": "Ignore throw statements with comments that match these strings."
+        },
         "doesItThrow.trace.server": {
           "scope": "window",
           "type": "string",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -195,7 +195,10 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
       const filePromises = analysis.relative_imports.map(async (relative_import) => {
         try {
           const file = await findFirstFileThatExists(textDocument.uri, relative_import)
-          return await readFile(file, 'utf-8')
+          return {
+            fileContent: await readFile(file, 'utf-8'),
+            fileUri: file
+          }
         } catch (e) {
           connection.console.log(`Error reading file ${inspect(e)}`)
           return undefined
@@ -207,8 +210,8 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
           return undefined
         }
         const opts = {
-          uri: textDocument.uri,
-          file_content: file,
+          uri: file.fileUri,
+          file_content: file.fileContent,
           ids_to_check: [],
           typescript_settings: {
             decorators: true

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -82,6 +82,7 @@ interface Settings {
   callToThrowSeverity: DiagnosticSeverity
   callToImportedThrowSeverity: DiagnosticSeverity
   includeTryStatementThrows: boolean
+  ignoreStatements: string[]
 }
 
 // The global settings, used when the `workspace/configuration` request is not supported by the client.
@@ -93,7 +94,8 @@ const defaultSettings: Settings = {
   functionThrowSeverity: 'Hint',
   callToThrowSeverity: 'Hint',
   callToImportedThrowSeverity: 'Hint',
-  includeTryStatementThrows: false
+  includeTryStatementThrows: false,
+  ignoreStatements: ['@it-throws', '@does-it-throw-ignore']
 }
 // 👆 very unlikely someone will have more than 1 million throw statements, lol
 // if you do, might want to rethink your code?
@@ -187,7 +189,8 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
       call_to_imported_throw_severity:
         settings?.callToImportedThrowSeverity ?? defaultSettings.callToImportedThrowSeverity,
       call_to_throw_severity: settings?.callToThrowSeverity ?? defaultSettings.callToThrowSeverity,
-      include_try_statement_throws: settings?.includeTryStatementThrows ?? defaultSettings.includeTryStatementThrows
+      include_try_statement_throws: settings?.includeTryStatementThrows ?? defaultSettings.includeTryStatementThrows,
+      ignore_statements: settings?.ignoreStatements ?? defaultSettings.ignoreStatements
     } satisfies InputData
     const analysis = parse_js(opts) as ParseResult
 


### PR DESCRIPTION
## Ignoring Throw Statement Warnings

You can ignore throw statement warnings by adding the following comment to the line above the throw statement:

```typescript
const someThrow = () => {
  // @does-it-throw-ignore
  throw new Error("This will not be reported");
};
```

Any calls to functions/methods that `throw` that are marked with the `@it-throws` or `@does-it-throw-ignore` comment will also be ignored as a result. For example:

```typescript
const someThrow = () => {
  // @it-throws
  throw new Error("This will not be reported");
};

const callToThrow = () => {
  someThrow(); // This will not be reported
};
```

You can configure the string to match with the following vscode/LSP settings:
| Option | Description | Default |
| ------ | ----------- | ------- |
| `ignoreStatements` | A list/array of statements to ignore. | `["@it-throws", "@does-it-throw-ignore"]` |

Let me know if you have any feedback!