### PR TITLE
fix: enhance call to throw logic and handle return statements 

### DIFF
--- a/crates/does-it-throw/src/fixtures/callExpr.ts
+++ b/crates/does-it-throw/src/fixtures/callExpr.ts
@@ -39,3 +39,11 @@ SomeRandomCall2(() => {
 connection.oneWithASecondArg({}, () => {
   throw new Error('hi khue')
 })
+
+const testGetter = {
+  get test() {
+    SomeThrow()
+  }
+}
+
+const array = [SomeThrow(), SomeThrow2()]

--- a/crates/does-it-throw/src/fixtures/returnStatement.ts
+++ b/crates/does-it-throw/src/fixtures/returnStatement.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+const someThrow = () => {
+  if (something) {
+    while (true) {
+      throw new Error("oh no");
+    }
+  } else {
+    for (let i = 0; i < 10; i++) {
+      throw new Error("oh no");
+    }
+  }
+}
+class Test {
+  badMethod() {
+    throw new Error("oh no");
+  }
+}
+
+const callToSomeThrow = () => {
+  const testMethod = new Test();
+  return {
+    test: someThrow(),
+    testing: () => someThrow(),
+    array: [someThrow(), someThrow()],
+    object: { test: someThrow() },
+    class: testMethod.badMethod(),
+  }
+}
+
+function test() {
+  return someThrow();
+}

--- a/crates/does-it-throw/src/lib.rs
+++ b/crates/does-it-throw/src/lib.rs
@@ -10,7 +10,7 @@ extern crate swc_ecma_ast;
 extern crate swc_ecma_parser;
 extern crate swc_ecma_visit;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use std::vec;
 
@@ -94,10 +94,11 @@ pub fn analyze_code(
   };
   throw_collector.visit_module(&module);
   let mut call_collector = CallFinder {
+    processed_calls: HashSet::new(),
     functions_with_throws: throw_collector.functions_with_throws.clone(),
     calls: HashSet::new(),
     current_class_name: None,
-    instantiations: HashSet::new(),
+    instantiations: HashMap::new(),
     function_name_stack: vec![],
     object_property_stack: vec![],
   };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,12 @@
     "throw finder",
     "throw",
     "javascript",
-    "typescript"
+    "typescript",
+    "lsp",
+    "language server",
+    "exceptions",
+    "extension",
+    "exception finder"
   ],
   "galleryBanner": {
     "color": "#050b1f",

--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,8 @@
     "lsp",
     "language server",
     "exceptions",
-    "extension"
+    "extension",
+    "exception finder"
   ],
   "qna": "https://github.com/michaelangeloio/does-it-throw/discussions",
   "dependencies": {


### PR DESCRIPTION
This PR closes #114 .

Summary: 
- return statements weren't handled for calls to throws, this PR addresses that by updating the AST implementation
- the logic for calls to throw is now greatly enhanced because we are now letting `swc_ecma_ast` handle the traversal of the expressions.  For example, we were only handling `call_expr` before, but now all expressions should be handled: `Arrow`, `CallExpr`, `Array`, etc. 